### PR TITLE
ocrd-tool.json: add content-type, make required

### DIFF
--- a/ocrd_typegroups_classifier/ocrd-tool.json
+++ b/ocrd_typegroups_classifier/ocrd-tool.json
@@ -12,12 +12,14 @@
         "recognition/font-identification"
       ],
       "input_file_grp": ["OCR-D-IMG"],
-      "output_file_grp": ["OCR-D-IMG-FONTS"],
+      "output_file_grp": ["OCR-D-FONTS"],
       "parameters": {
         "network": {
-          "description": "The file name of the neural network to use, including sufficient path information",
+          "description": "The neural network pickle file to use",
           "type": "string",
-          "required": false
+          "format": "uri",
+          "content-type": "application/octet-stream",
+          "required": true
         },
         "stride": {
           "description": "Stride applied to the CNN on the image. Should be between 1 and 224. Smaller values increase the computation time.",


### PR DESCRIPTION
This module already distributes its model in the module directory:
https://github.com/OCR-D/ocrd_typegroups_classifier/blob/1ed0cb14f0860f33f8461b2b596448ec5598ce35/ocrd_typegroups_classifier/processor.py#L48

But due to the subdirectory, we cannot use the new mechanism for preinstalled resources directly. So either we make `model` not required again (but then the user still cannot see the model file whith `-L` or `resmgr list-installed`), or we move it to the top module directory (and can remove that line).